### PR TITLE
feat: uses reference as opposed to value for writer

### DIFF
--- a/brrrr-lib/Cargo.toml
+++ b/brrrr-lib/Cargo.toml
@@ -18,3 +18,7 @@ criterion = "0.3"
 [[bench]]
 harness = false
 name = "read_fasta"
+
+[[example]]
+name = "hello_world_parquet"
+path = "examples/fa2jsonl.rs"

--- a/brrrr-lib/benches/read_fasta.rs
+++ b/brrrr-lib/benches/read_fasta.rs
@@ -18,7 +18,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let filename = format!("./{}/10000.fasta", path);
             let f = File::open(filename).expect("Error opening file.");
-            let _ = brrrr_lib::json_writer::fa2jsonl(f, sink());
+            let _ = brrrr_lib::json_writer::fa2jsonl(f, &mut sink());
         })
     });
 }

--- a/brrrr-lib/examples/fa2jsonl.rs
+++ b/brrrr-lib/examples/fa2jsonl.rs
@@ -1,0 +1,11 @@
+// (c) Copyright 2020 Trent Hauck
+// All Rights Reserved
+
+use std::io::stdout;
+
+use brrrr_lib::json_writer::fa2jsonl;
+
+fn main() {
+    let example_input = b">A\nATCG\n>B\nGCTA" as &[u8];
+    fa2jsonl(example_input, &mut stdout()).expect("Error... :(");
+}

--- a/brrrr-lib/src/json_writer.rs
+++ b/brrrr-lib/src/json_writer.rs
@@ -41,7 +41,7 @@ impl<W: Write> writer::RecordWriter for JsonRecordWriter<W> {
 ///
 /// * `input` an input that implements the Read trait.
 /// * `output` an output that implements the Write trait.
-pub fn fq2jsonl<R: Read, W: Write>(input: R, output: W) -> Result<()> {
+pub fn fq2jsonl<R: Read, W: Write>(input: R, output: &mut W) -> Result<()> {
     let reader = fastq::Reader::new(input);
     let record_writer = &mut JsonRecordWriter::new(output);
 
@@ -65,7 +65,7 @@ pub fn fq2jsonl<R: Read, W: Write>(input: R, output: W) -> Result<()> {
 ///
 /// * `input` an input that implements the Read trait.
 /// * `output` an output that implements the Write trait.
-pub fn fa2jsonl<R: Read, W: Write>(input: R, output: W) -> Result<()> {
+pub fn fa2jsonl<R: Read, W: Write>(input: R, output: &mut W) -> Result<()> {
     let reader = fasta::Reader::new(input);
     let record_writer = &mut JsonRecordWriter::new(output);
 
@@ -90,7 +90,11 @@ pub fn fa2jsonl<R: Read, W: Write>(input: R, output: W) -> Result<()> {
 /// * `input` an input that implements the Read trait.
 /// * `output` an output that implements the Write trait.
 /// * `gff_type` the underlying gff type.
-pub fn gff2jsonl<R: Read, W: Write>(input: R, output: W, gff_type: gff::GffType) -> Result<()> {
+pub fn gff2jsonl<R: Read, W: Write>(
+    input: R,
+    output: &mut W,
+    gff_type: gff::GffType,
+) -> Result<()> {
     let mut reader = gff::Reader::new(input, gff_type);
     let record_writer = &mut JsonRecordWriter::new(output);
 
@@ -106,4 +110,21 @@ pub fn gff2jsonl<R: Read, W: Write>(input: R, output: W, gff_type: gff::GffType)
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fa2jsonl() {
+        let input = b">A\nATCG\n" as &[u8];
+
+        let mut output = Vec::new();
+        fa2jsonl(input, &mut output).unwrap();
+
+        let output_str = String::from_utf8(output).unwrap();
+        let expected_output = "{\"id\":\"A\",\"desc\":null,\"seq\":\"ATCG\"}\n".to_string();
+        assert_eq!(output_str, expected_output);
+    }
 }

--- a/brrrr/src/main.rs
+++ b/brrrr/src/main.rs
@@ -80,10 +80,10 @@ fn print_completions<G: Generator>(app: &mut App) {
 fn main() -> Result<()> {
     match Brrrr::parse() {
         Brrrr::Fa2jsonl { input } => match input {
-            None => json_writer::fa2jsonl(stdin(), stdout()),
+            None => json_writer::fa2jsonl(stdin(), &mut stdout()),
             Some(input) => {
                 let f = File::open(input).expect("Error opening file.");
-                json_writer::fa2jsonl(f, stdout())
+                json_writer::fa2jsonl(f, &mut stdout())
             }
         },
         Brrrr::Fa2pq {
@@ -95,17 +95,17 @@ fn main() -> Result<()> {
             output_file_name,
         } => parquet_writer::fq2pq(input_file_name.as_str(), output_file_name.as_str()),
         Brrrr::Gff2jsonl { input, gff_type } => match input {
-            None => json_writer::gff2jsonl(stdin(), stdout(), gff_type),
+            None => json_writer::gff2jsonl(stdin(), &mut stdout(), gff_type),
             Some(input) => {
                 let f = File::open(input).expect("Error opening file.");
-                json_writer::gff2jsonl(f, stdout(), gff_type)
+                json_writer::gff2jsonl(f, &mut stdout(), gff_type)
             }
         },
         Brrrr::Fq2jsonl { input } => match input {
-            None => json_writer::fq2jsonl(stdin(), stdout()),
+            None => json_writer::fq2jsonl(stdin(), &mut stdout()),
             Some(input) => {
                 let f = File::open(input).expect("Error opening file.");
-                json_writer::fq2jsonl(f, stdout())
+                json_writer::fq2jsonl(f, &mut stdout())
             }
         },
         Brrrr::Completion { gen_type } => {


### PR DESCRIPTION
Passing by value caused issues for cases where the underlying object does not implement the Copy trait, because once passed inside the function scope it would be owned by that function.